### PR TITLE
docs: add THIRD_PARTY_LICENSES to `packages/env/src/lib/parsers`

### DIFF
--- a/packages/env/src/lib/parsers/THIRD_PARTY_LICENSES
+++ b/packages/env/src/lib/parsers/THIRD_PARTY_LICENSES
@@ -1,0 +1,13 @@
+Copyright 2019 Skyra Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
It is definitely based on Skyra's code 👀